### PR TITLE
Fibtoprime

### DIFF
--- a/packagename/example_c.pyx
+++ b/packagename/example_c.pyx
@@ -1,8 +1,24 @@
-def fib(n):
-    """Returns the Fibonacci series up to n."""
-    a, b = 0, 1
-    c = []
-    while b < n:
-        c.append(b)
-        a, b = b, a + b
-    return c
+def primes(int imax):
+    """Returns prime numbers up to imax. This can only get up to 10000
+    prime numbers."""
+    cdef int n, k, i
+    cdef int p[10001]
+    result = []
+    k = 0
+    n = 2
+    i = 0
+    
+    if imax>10000:
+        imax = 10000
+    while len(result) < imax:
+        i = 0
+        while i < k and n % p[i] != 0:
+            i = i + 1
+        if i == k:
+            p[k] = n
+            k = k + 1
+            result.append(n)
+            if k>10000:
+                break
+        n = n + 1
+    return result

--- a/packagename/example_mod.py
+++ b/packagename/example_mod.py
@@ -1,35 +1,62 @@
-def fib(n):
-    """Returns the Fibonacci series up to n."""
-    a, b = 0, 1
-    c = []
-    while b < n:
-        c.append(b)
-        a, b = b, a + b
-    return c
-
-def do_fib(n, usecython=False):
+def primes(imax):
+    """Returns prime numbers up to imax.  This can only get up to 10000
+    prime numbers."""
+    p = range(10000)
+    result = []
+    k = 0
+    n = 2
+    if imax>10000:
+        imax = 10000
+    while len(result) < imax:
+        i = 0
+        while i < k and n % p[i] != 0:
+            i = i + 1
+        if i == k:
+            p[k] = n
+            k = k + 1
+            result.append(n)
+            if k>10000:
+                break
+        n = n + 1
+    return result
+    
+def do_primes(n, usecython=False):
     if usecython:
-        from .example_c import fib as cfib
+        from .example_c import primes as cprimes
 
-        print 'Using cython-based fib'
+        print 'Using cython-based primes'
 
-        return cfib(n)
+        return cprimes(n)
     else:
-        print 'Using pure python fib'
+        print 'Using pure python primes'
 
-        return fib(n)
+        return primes(n)
 
 
 def main(args=None):
     from astropy.utils.compat import argparse
+    from time import time
 
     parser = argparse.ArgumentParser(description='Process some integers.')
     parser.add_argument('-c', '--use-cython', dest='cy', action='store_true',
-                        help='Use the Cython-based Fibonacci generator.')
+                        help='Use the Cython-based Prime number generator.')
+    parser.add_argument('-t', '--timing', dest='time', action='store_true',
+                        help='Time the Fibonacci generator.')
+    parser.add_argument('-p', '--print', dest='prnt', action='store_true',
+                        help='Print all of the Prime numbers.')
     parser.add_argument('n', metavar='N', type=int,
-                        help='Run Fibonacci series up to this number.')
+                        help='Get Prime numbers up to this number.')
+    
 
     res = parser.parse_args(args)
 
-    fib = do_fib(res.n, res.cy)
-    print fib
+    pre = time()
+    prms = do_primes(res.n, res.cy)
+    post = time()
+    
+    print 'Found',len(prms),'Prime numbers with',prms[-1],'as largest:'
+    
+    if res.time:
+        print 'Running time:',post-pre,'s'
+    if res.prnt:
+        print prms


### PR DESCRIPTION
This changes the guts of the cython example to something that actually makes sene to do with Cython - the Fibonnaci example was actually _slower_ using Cython than pure python because of the overhead for calling the function seems to be much larger than the actual difference between the guts of the algorithm (and the C version can't go past the machine long limit).  So this instead uses a prime number generator, which is a much better showcase of when Cython is useful (nested for loops).

(Note that this pull request is based on astrofrog/package-template#6, so you'll want to merge that first if you choose to merge this... or to see just what this does, diff against that branch)
